### PR TITLE
CD-224014: use v4.4.0 but support resque 1.26

### DIFF
--- a/lib/resque/scheduler/lock/resilient.rb
+++ b/lib/resque/scheduler/lock/resilient.rb
@@ -43,7 +43,7 @@ module Resque
           @locked_sha = nil if refresh
 
           @locked_sha ||=
-            Resque.data_store.redis.script(:load, <<-EOF.gsub(/^ {14}/, ''))
+            Resque.redis.script(:load, <<-EOF.gsub(/^ {14}/, ''))
               if redis.call('GET', KEYS[1]) == ARGV[1]
               then
                 redis.call('EXPIRE', KEYS[1], #{timeout})
@@ -62,7 +62,7 @@ module Resque
           @acquire_sha = nil if refresh
 
           @acquire_sha ||=
-            Resque.data_store.redis.script(:load, <<-EOF.gsub(/^ {14}/, ''))
+            Resque.redis.script(:load, <<-EOF.gsub(/^ {14}/, ''))
               if redis.call('SETNX', KEYS[1], ARGV[1]) == 1
               then
                 redis.call('EXPIRE', KEYS[1], #{timeout})

--- a/lib/resque/scheduler/locking.rb
+++ b/lib/resque/scheduler/locking.rb
@@ -100,7 +100,7 @@ module Resque
       end
 
       def redis_master_version
-        ::Resque.data_store.redis.info['redis_version'].to_f
+        ::Resque.redis.info['redis_version'].to_f
       end
     end
   end

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -2,7 +2,7 @@
 require_relative 'test_helper'
 
 context 'scheduling jobs with hooks' do
-  setup { Resque.data_store.redis.flushall }
+  setup { Resque.redis.flushall }
 
   test 'before_schedule hook that does not return false should be enqueued' do
     enqueue_time = Time.now

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -89,7 +89,7 @@ context 'Resque::Scheduler::Locking' do
   end
 
   test 'should use the basic lock mechanism for <= Redis 2.4' do
-    Resque.data_store.redis.stubs(:info).returns('redis_version' => '2.4.16')
+    Resque.redis.stubs(:info).returns('redis_version' => '2.4.16')
 
     assert_equal @subject.master_lock.class, Resque::Scheduler::Lock::Basic
   end
@@ -227,7 +227,7 @@ context 'Resque::Scheduler::Lock::Resilient' do
       assert @lock.acquire!
       assert @lock.locked?
 
-      Resque.data_store.redis.script(:flush)
+      Resque.redis.script(:flush)
 
       assert @lock.locked?
       assert_false @lock.acquire!

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -6,7 +6,7 @@ context 'Resque::Scheduler' do
     ENV['VERBOSE'] = nil
     nullify_logger
     Resque::Scheduler.dynamic = false
-    Resque.data_store.redis.flushall
+    Resque.redis.flushall
     Resque::Scheduler.clear_schedule!
   end
 

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -7,7 +7,7 @@ context 'Resque::Scheduler' do
       c.dynamic = false
       c.poll_sleep_amount = 0.1
     end
-    Resque.data_store.redis.flushall
+    Resque.redis.flushall
     Resque::Scheduler.quiet = true
     Resque::Scheduler.clear_schedule!
     Resque::Scheduler.send(:instance_variable_set, :@scheduled_jobs, {})

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -9,7 +9,7 @@ context 'Resque::Scheduler' do
       c.env = nil
       c.app_name = nil
     end
-    Resque.data_store.redis.flushall
+    Resque.redis.flushall
     Resque::Scheduler.clear_schedule!
     Resque::Scheduler.send(:instance_variable_set, :@scheduled_jobs, {})
     Resque::Scheduler.send(:instance_variable_set, :@shutdown, false)


### PR DESCRIPTION
- [ ] @johnny-lai 

We might want to leave this branch name as is and not merge this back to v4.4.0 but creating a PR just in case you feel this is important to merge back, otherwise we can point enterprise at v4.4.0_fork_resque_126 which I have tested.

This PR moves the v4.4.0 branch back a little to resque 1.26 as it had moved to resque 1.27 inadvertently even though the gemfile spec says it supports 1.26 but the code changes don't reflect that.