### PR TITLE
CD-227789 Upgrade redis gem dependency in gemspec to minimum 4.2

### DIFF
--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.40.0'
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
-  spec.add_runtime_dependency 'redis', '>= 3.3'
+  spec.add_runtime_dependency 'redis', '~> 4.2.0'
   spec.add_runtime_dependency 'resque', '>= 1.26'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end


### PR DESCRIPTION
## Reviewers

- [x] @abdulchaudhrycoupa 
- [ ] @johnny-lai 

## Summary of change

`resque-scheduler` has direct dependency on redis gem in prod env

```
resque (= 1.26.0) was resolved to 1.26.0, which depends on
        redis-namespace (~> 1.6) was resolved to 1.6.0, which depends on
          redis (>= 3.0.4)
fakeredis (= 0.7.0) was resolved to 0.7.0, which depends on
      redis (>= 3.2, < 5.0)
redis-rails (= 5.0.2) was resolved to 5.0.2, which depends on
      redis-store (>= 1.2, < 2) was resolved to 1.4.1, which depends on
        redis (>= 2.2, < 5)
 resque-scheduler was resolved to 4.4.0, which depends on
      redis (>= 3.3)
```

Though in resque-scheduler, it uses redis (>= 3.3), `Gemfile.lock` in enterprise is still locked at `3.3.5`. https://github.com/coupa/coupa_development/blob/7e64d0277f13d4edb93f1934339c4969cdac4aa7/Gemfile.lock#L1685

Hence setting the minimum version of `redis` to `4.2` so that when enterprise is upgraded to use redis v6, it has the `redis` gem set to `4.2`. 

**This PR will be merged when the enterprise PR for redis v6 is ready for merge.**